### PR TITLE
Contributor Tracker Template

### DIFF
--- a/templates/Contributor_Tracker_Template.md
+++ b/templates/Contributor_Tracker_Template.md
@@ -1,0 +1,33 @@
+# OpenGov Africa — Contributor Tracker Template
+
+**Purpose:** A simple, shareable tracker to record contributors, roles, tasks and completed work. Store this in the organization Drive (or convert to Google Sheet) for live tracking.
+
+**Drive folder (suggested):** https://drive.google.com/drive/folders/1EF5yA7_0STfUdrRYWvRItOtY95bhVVQS
+
+---
+
+## Contributor Tracker (table)
+
+| S.No | Contributor Name | GitHub Username | Role / Area | Assigned Task(s) | Status | Priority | PR / Issue Link | Start Date | Completion Date | Notes |
+|------|------------------|-----------------|-------------|------------------|--------|----------|-----------------|------------|-----------------|-------|
+| 1 | John Doe | @johndoe | Documentation | Mentee Onboarding Checklist | Completed | Medium | https://github.com/OpenGovAfrica/hacktoberfest/pull/123 | 2025-10-05 | 2025-10-05 | Uploaded to Drive |
+| 2 | Jane Smith | @janesmith | Mentor / Review | PR reviews (week 1) | In Progress | High | — | 2025-10-06 | — | Weekly slots: Tue, Thu |
+| 3 | — | — | — | — | — | — | — | — | — | — |
+
+---
+
+## How to use
+1. Add **one row per task per contributor**. If a contributor works on multiple tasks, add separate rows for each task.  
+2. Update **Status** as `Not Started`, `In Progress`, `Completed`, or `Blocked`.  
+3. Use **Priority** to indicate urgency (`High`, `Medium`, `Low`).  
+4. Keep **PR / Issue Link** clickable so reviewers can jump directly to contributions.  
+5. Update **Completion Date** when PR is merged or task is finished.
+
+---
+
+
+
+## Notes & best practices
+- Update weekly or after a PR is merged.  
+- Use this tracker for reporting and for Hacktoberfest acceptance validation.  
+- Keep rows short and use PR links for detail — don’t duplicate long descriptions here.


### PR DESCRIPTION
Fixes #7
## Description
Added a simple Contributor Tracker Template in Markdown to help track contributors, roles, tasks and completion dates. 

---

### This is a Google Sheet version of the markdown table in the repo, which can be used for live tracking:
**Google Sheet Link (view only):** [OpenGov Africa — Contributor Tracker Template](https://docs.google.com/spreadsheets/d/12byzTaEOX3IpsqfvOjXBAp-kP1vo3XziDMG-xPNmRhM/edit?usp=sharing)

## Purpose
Helps the team track merged/active contributions and assignments during Hacktoberfest and beyond.

## Related Issue
Related to: #7 

## Checklist
- [x] Added template at `templates/Contributor_Tracker_Template.md`
- [x] Instructions included for conversion to Google Sheets and Drive upload

The Markdown file is also included in this PR (`Contributor_Tracker_Template.md`) so the organization can later use it.
